### PR TITLE
Add ticket URL to Debian's RT

### DIFF
--- a/ticketconfig.py
+++ b/ticketconfig.py
@@ -61,6 +61,7 @@ class TicketConfig:
             '~/.rtrc-debian',
             h.ReGroupFixup('[0-9]+: *(.*)$'),
             prefix='DebianRT',
+            postfix=' - https://rt.debian.org/Ticket/Display.html?id=%s'
             ))
         p.append( h.TicketHtmlTitleProvider( 'bts.grml.org',
             'http://bts.grml.org/grml/issue',

--- a/ticketconfig.py
+++ b/ticketconfig.py
@@ -61,7 +61,7 @@ class TicketConfig:
             '~/.rtrc-debian',
             h.ReGroupFixup('[0-9]+: *(.*)$'),
             prefix='DebianRT',
-            postfix=' - https://rt.debian.org/Ticket/Display.html?id=%s'
+            postfix=' - https://rt.debian.org/%s'
             ))
         p.append( h.TicketHtmlTitleProvider( 'bts.grml.org',
             'http://bts.grml.org/grml/issue',


### PR DESCRIPTION
Dunno if this works, but maybe this adds a URL to the end of the IRC notification for Debian's RT.