### PR TITLE
implement a GitLab title grabber for Tor

### DIFF
--- a/ticketconfig.py
+++ b/ticketconfig.py
@@ -50,6 +50,14 @@ class TicketConfig:
             h.ReGroupFixup('.*?(.*) . Pull Request #[0-9]+ . TheTorProject/ooni-probe . GitHub$'),
             prefix='github-OONI-PR'
             ))
+        p.append( h.GitlabTitleProvider( 'gitlab.torproject.org',
+            'https://gitlab.torproject.org/',
+            fixup=None,
+            prefix='gitlab',
+            postfix=None,
+            default_re=r'(?<!\w)((?<path>[\w/]+)#(?<number>[0-9]{4,}))(?:(?=\W)|$',
+            status_finder = None,
+            ))
         p.append( h.TicketHtmlTitleProvider( 'bugs.debian.org',
             'http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=',
             h.ReGroupFixup('#[0-9]+ - (.*) - Debian Bug report logs$'),
@@ -107,6 +115,7 @@ class TicketConfig:
     def _setup_channels(self):
         for tor in ('#ooni', '#nottor', '#tor*'):
             self.providers['trac.torproject.org'    ].addChannel(tor, default=True)
+            self.providers['gitlab.torproject.org'  ].addChannel(tor)
             self.providers['proposal.torproject.org'].addChannel(tor, regex='(?<!\w)[Pp]rop#([0-9]+)(?:(?=\W)|$)')
 
         self.providers['github.com-tor-ooni-probe-pull'].addChannel('#ooni', regex='(?<!\w)(?:PR#|https://github.com/TheTorProject/ooni-probe/pull/)([0-9]+)(?:(?=\W)|$)')

--- a/tickethelpers.py
+++ b/tickethelpers.py
@@ -157,9 +157,9 @@ class TicketHtmlTitleProvider(BaseProvider):
         self.url = url
         self.status_finder = status_finder
 
-    def _gettitle(self, ticketnumber):
+    def _gettitle(self, ticketnumber, url=None):
         try:
-            response = urllib.request.urlopen('%s%s'%(self.url, ticketnumber))
+            response = urllib.request.urlopen('%s%s'%(url or self.url, ticketnumber))
         except urllib.error.HTTPError as e:
             raise IndexError(e)
 
@@ -176,6 +176,18 @@ class TicketHtmlTitleProvider(BaseProvider):
             if status is not None:
                 title = "%s - [%s]" % (title, status)
         return (title, True)
+
+
+class GitlabTitleProvider(TicketHtmlTitleProvider):
+    """A ticket information provider that extracts the title
+       tag from GitLab issues at $url/$path/-/issues/$ticketnumber."""
+    def __getitem__(self, ticketnumber):
+        path, ticketnumber = ticketnumber.split('#')
+        url = '%s/%s/-/issues/%' % (self.url, path, ticketnumber)
+        title = super().__getitem__(ticketnumber, url=url)
+        # override postfix because it does not support multiple components
+        return title + ' - ' + url
+
 
 class TorProposalProvider(BaseProvider):
     def __init__(self, name, fixup=None, prefix=None, default_re=None, postfix=None):


### PR DESCRIPTION
This implements a crude GitlabTitleProvider based on the
TicketHtmlTitleProvider. It's a little hackish because it requires
extra backflips to take into account the "path" section of the
shortcut.

This should parse patterns like PATH#NUMBER and turn those into
https://gitlab.torproject.org/PATH/-/issues/NUMBER URLs. Then it will
extract the title from that page as normal *but* it will add the URL
as a postfix manually, instead of relying on 'postfix' because that
assumes we only have one variable component in the URL.

That required, in turn, hacking at the _gittitle function but that was
done in a backwards-compatible way, so that should work.