### PR TITLE
Stop providing links for invalid paths

### DIFF
--- a/tickethelpers.py
+++ b/tickethelpers.py
@@ -295,6 +295,10 @@ class GitlabTitleProvider(TicketHtmlTitleProvider):
         path, ticketnumber = ticketnumber
         url = '%s%s/-/issues/' % (self.url, path)
         res = super()._gettitle(ticketnumber, url=url)
+        # Instead of responding with an HTTP 404 error, GitLab returns the sign in page
+        # if the repository is either not public or doesn't exist
+        if (res['title'] == "Sign in · GitLab"):
+            raise IndexError('Project not found')
         res['url'] = url
         res['path'] = path
         res['ticketnumber'] = ticketnumber


### PR DESCRIPTION
Gitlab can't (or doesn't, for security reasons) tell the difference
between a non-existent or private repository. So, if an invalid Gitlab
ticket path is provided, it will return the path along with a ticket
title for the sign in page. This change raises an IndexError if the path
is invalid.