### PR TITLE
Use Gitlab API to fetch ticket titles and urls

### DIFF
--- a/ticketconfig.py
+++ b/ticketconfig.py
@@ -53,15 +53,13 @@ class TicketConfig:
         p.append( h.GitlabTitleProvider( 'gitlab.torproject.org',
             'https://gitlab.torproject.org/',
             prefix='tor:',
-            default_re=r'(?<!\w)(?:tor:|gitlabtpo:|https://gitlab.torproject.org/)(?P<path>[\w-]+/[\w/-]*\w)(?:#|/-/issues/)(?P<number>[0-9]+)(?:(?=\W)|$)',
-            postfix=' - https://bugs.torproject.org/%s/%s',
-            status_finder = h.GitLabStatusExtractor,
+            default_re=r'(?<!\w)(?:tor:|gitlabtpo:|https://gitlab.torproject.org/)(?P<path>[\w/-]*\w)(?:#|/-/issues/)(?P<number>[0-9]+)(?:(?=\W)|$)',
             ))
         p.append( h.TicketHtmlTitleProvider( 'gitlab.torproject.org-legacy',
             'https://gitlab.torproject.org/legacy/trac/-/issues/',
             prefix='tor',
             fixup=h.ReGroupFixup('(.*?) \(#[0-9]+\) . Issues . .*? . GitLab$'),
-            default_re=r'(?<!\w)(?:[tT]or#|https://trac.torproject.org/projects/tor/ticket/)([0-9]{4,})(?:(?=\W)|$)',
+            default_re=r'(?<!\w)(?:#|https://trac.torproject.org/projects/tor/ticket/)([0-9]{4,})(?:(?=\W)|$)',
             postfix=' - https://bugs.torproject.org/%s',
             status_finder = h.GitLabStatusExtractor,
             ))
@@ -122,7 +120,7 @@ class TicketConfig:
     def _setup_channels(self):
         for tor in ('#ooni', '#nottor', '#tor*', '#tpo-admin'):
             self.providers['gitlab.torproject.org-legacy'].addChannel(tor, default=True)
-            self.providers['gitlab.torproject.org'       ].addChannel(tor, regex=r'(?<!\w)(?P<path>[\w-]+/[\w/-]*\w)#(?P<number>[0-9]+)(?:(?=\W)|$)')
+            self.providers['gitlab.torproject.org'       ].addChannel(tor, regex=r'(?<!\w)(?P<path>[\w/-]*\w)#(?P<number>[0-9]+)(?:(?=\W)|$)')
             self.providers['proposal.torproject.org'     ].addChannel(tor, regex='(?<!\w)[Pp]rop#([0-9]+)(?:(?=\W)|$)')
 
         self.providers['github.com-tor-ooni-probe-pull'].addChannel('#ooni', regex='(?<!\w)(?:PR#|https://github.com/TheTorProject/ooni-probe/pull/)([0-9]+)(?:(?=\W)|$)')


### PR DESCRIPTION
The Gitlab API provides a more intuitive way to fetch ticket information
and urls. This change allows developers to reference tickets from projects with
simply projectname#ticketnumber.

This has several advantages:

- It's been a pain to have to type of e.g. 'tpo/anti-censorship/pluggable-transports/snowflake#40001' to reference new snowflake tickets. This allows developers to just type out 'snowflake#40001'. If there is (for some reason) a name collision, it will raise an IndexError, forcing the developer to specify a more specific path

- The Gitlab API is a more sustainable way of determining ticket titles, status, and urls. If, for some reason, Gitlab changes their WebUI we don't have to update the ticketbot.

- This fixes another current issue where a user will specify an invalied path+ticket number and ticketbot just returns the Gitlab sign in page.

Note: typing `tor#ticketnumber` now triggers only the new gitlab provider, and not the legacy provider. IMO this is okay, because most people don't use that layout to refer to non core/tor tickets. If this is a problem, we can revert the `default_re` for the legacy provider and the bot will list both links.